### PR TITLE
refactor: same foreground background

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ npm-debug.log
 /lib/es6/
 /dist
 /node_modules/
+coverage

--- a/__tests__/Color_test.re
+++ b/__tests__/Color_test.re
@@ -1,6 +1,21 @@
 open Jest;
 open Expect;
 
+testAll(
+  "colors are equal",
+  [
+    ("#ffffff", "#ffffff"),
+    ("ffffff", "ffffff"),
+    ("rgb(255, 255, 255)", "rgb(255, 255, 255)"),
+    ("rgb(255,255,255)", "rgb(255, 255, 255)"),
+    ("hsl(255, 30%, 40%)", "hsl(255, 30%, 40%)"),
+    ("hsl(255,30,40)", "hsl(255, 30%, 40%)"),
+    ("#ffffff", "rgb(255, 255, 255)"),
+  ],
+  ((fg, bg)) =>
+  expect(Color.score(fg, bg)) |> toEqual(1.0)
+);
+
 describe("#score", () => {
   test("handles white on black", () =>
     expect(Color.score("#ffffff", "#000000")) |> toEqual(21.0)

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test:ci": "jest",
     "test:watch": "jest --watch",
     "rollup:build": "rollup -c",
-    "prepare": "npm run build && npm run rollup:build"
+    "prepare": "npm run build && npm run rollup:build",
+    "test:coverage": "jest --coverage"
   },
   "keywords": [
     "WCAG",

--- a/src/Color.re
+++ b/src/Color.re
@@ -28,13 +28,17 @@ let parseColor = color =>
   |> Luminance.convert
   |> (v => v +. 0.05);
 
-let score = (fg, bg) => {
-  (
-    switch (fg |> parseColor, bg |> parseColor) {
-    | (f, b) when f > b => f /. b
-    | (f, b) => b /. f
-    }
-  )
-  |> Js.Float.toFixedWithPrecision(~digits=2)
-  |> Js.Float.fromString;
+let score = (foreground, background) => {
+  switch (foreground |> Utils.removeHash, background |> Utils.removeHash) {
+  | (fg, bg) when fg === bg => 1.0
+  | (fg, bg) =>
+    (
+      switch (fg |> parseColor, bg |> parseColor) {
+      | (f, b) when f > b => f /. b
+      | (f, b) => b /. f
+      }
+    )
+    |> Js.Float.toFixedWithPrecision(~digits=2)
+    |> Js.Float.fromString
+  };
 };

--- a/src/HEX.re
+++ b/src/HEX.re
@@ -11,8 +11,5 @@ let hexParts = t => {
 };
 
 let convert = hex => {
-  hex
-  |> Js.String.replace("#", "")
-  |> hexParts
-  |> Js.Array.map(x => "0x" ++ x |> float_of_string);
+  hex |> hexParts |> Js.Array.map(x => "0x" ++ x |> float_of_string);
 };

--- a/src/Utils.re
+++ b/src/Utils.re
@@ -1,0 +1,1 @@
+let removeHash = str => str |> Js.String.replace("#", "");


### PR DESCRIPTION
Fixes #1 

This skips calculations when strings are **exactly** equal. For cases where two colors are the same but in different formats, e.g. `#ffffff` and `rgb(255, 255, 255)`, the calculations still need to be made.