### PR TITLE
feat: add score

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,24 +15,56 @@ npm install wcag-color
 
 ## API
 
-### Score
+### Ratio
 
-`score` takes two colors, a foreground color, and background color, and returns a contrast ratio. `score` accepts most color formats:
+`ratio` takes two colors, a foreground color, and background color, and returns a contrast ratio. `ratio` accepts most color formats:
 
 - **HEX** - normal (`#0088ff`), shorthand (`#08f`) and without hash (`08f`)
 - **RGB** - `rgb(255, 255, 255)`
 - **HSL** - `hsl(210, 100%, 40%)`
 
 ```js
-score(foreground: string, background: string) => number
+ratio(foreground: string, background: string) => number
 ```
 
 #### Example
 
 ```js
+import { ratio } from 'wcag-color'
+
+ratio('hsl(210, 100%, 40%)', '#ffffff') // 5.57
+```
+
+### Score
+
+`score` takes two colors and returns a score value. Read more below.
+
+```js
+score(foreground: string, background: string) => 'Fail' | 'AA Large' | 'AA' | 'AAA'
+```
+
+### Example
+
+```js
 import { score } from 'wcag-color'
 
-score('hsl(210, 100%, 40%)', '#ffffff') // 21
+score('hsl(210, 100%, 40%)', '#ffffff') // AA
+```
+
+### Score from ratio
+
+`scoreFromRatio` takes a ratio and returns a score value.
+
+```js
+scoreFromRatio(ratio: number) => 'Fail' | 'AA Large' | 'AA' | 'AAA'
+```
+
+### Example
+
+```js
+import { scoreFromRatio } from 'wcag-color'
+
+scoreFromRatio(7.5) // AAA
 ```
 
 ## Score and ratio

--- a/__tests__/Ratio_test.re
+++ b/__tests__/Ratio_test.re
@@ -13,57 +13,59 @@ testAll(
     ("#ffffff", "rgb(255, 255, 255)"),
   ],
   ((fg, bg)) =>
-  expect(Color.score(fg, bg)) |> toEqual(1.0)
+  expect(Ratio.calculate(fg, bg)) |> toEqual(1.0)
 );
 
-describe("#score", () => {
+describe("#calculate", () => {
   test("handles white on black", () =>
-    expect(Color.score("#ffffff", "#000000")) |> toEqual(21.0)
+    expect(Ratio.calculate("#ffffff", "#000000")) |> toEqual(21.0)
   );
 
   test("handles white on grayish", () =>
-    expect(Color.score("#ffffff", "#777777")) |> toEqual(4.48)
+    expect(Ratio.calculate("#ffffff", "#777777")) |> toEqual(4.48)
   );
 
   test("handles random colors (blue on pink)", () =>
-    expect(Color.score("#0088FF", "#C611AB")) |> toEqual(1.47)
+    expect(Ratio.calculate("#0088FF", "#C611AB")) |> toEqual(1.47)
   );
 
   test("handles hex without hash", () =>
-    expect(Color.score("ffffff", "777777")) |> toEqual(4.48)
+    expect(Ratio.calculate("ffffff", "777777")) |> toEqual(4.48)
   );
 
   test("handles hex with shorthand", () =>
-    expect(Color.score("fff", "777")) |> toEqual(4.48)
+    expect(Ratio.calculate("fff", "777")) |> toEqual(4.48)
   );
 
   test("handles hex with non-uniform shorthand", () =>
-    expect(Color.score("08f", "fff")) |> toEqual(3.52)
+    expect(Ratio.calculate("08f", "fff")) |> toEqual(3.52)
   );
 
   test("handles rgb colors", () =>
-    expect(Color.score("rgb(255,255,255)", "#777777")) |> toEqual(4.48)
+    expect(Ratio.calculate("rgb(255,255,255)", "#777777")) |> toEqual(4.48)
   );
 
   test("handles two rgb colors", () =>
-    expect(Color.score("rgb(255,255,255)", "rgb(77,77,77)"))
+    expect(Ratio.calculate("rgb(255,255,255)", "rgb(77,77,77)"))
     |> toEqual(8.45)
   );
 
   test("handles hsl colors without saturation", () =>
-    expect(Color.score("hsl(0, 0%, 20%)", "#ffffff")) |> toEqual(12.63)
+    expect(Ratio.calculate("hsl(0, 0%, 20%)", "#ffffff")) |> toEqual(12.63)
   );
 
   test("handles hsl colors with lightness lower than 50", () =>
-    expect(Color.score("hsl(210, 30%, 48%)", "#ffffff")) |> toEqual(4.47)
+    expect(Ratio.calculate("hsl(210, 30%, 48%)", "#ffffff"))
+    |> toEqual(4.47)
   );
 
   test("handles hsl colors with lightness higher than 50", () =>
-    expect(Color.score("hsl(210, 30%, 68%)", "#ffffff")) |> toEqual(2.35)
+    expect(Ratio.calculate("hsl(210, 30%, 68%)", "#ffffff"))
+    |> toEqual(2.35)
   );
 
   test("handles two hsl colors", () =>
-    expect(Color.score("hsl(0, 0%, 20%)", "hsl(0, 0%, 100%)"))
+    expect(Ratio.calculate("hsl(0, 0%, 20%)", "hsl(0, 0%, 100%)"))
     |> toEqual(12.63)
   );
 });

--- a/__tests__/Score_test.re
+++ b/__tests__/Score_test.re
@@ -1,0 +1,38 @@
+open Jest;
+open Expect;
+
+describe("#calculateFromRatio", () => {
+  test("handles AAA", () =>
+    expect(Score.calculateFromRatio(7.1)) |> toEqual("AAA")
+  );
+
+  test("handles AA", () =>
+    expect(Score.calculateFromRatio(4.6)) |> toEqual("AA")
+  );
+
+  test("handles AA Large", () =>
+    expect(Score.calculateFromRatio(3.9)) |> toEqual("AA Large")
+  );
+
+  test("handles white on grayish", () =>
+    expect(Score.calculateFromRatio(2.9)) |> toEqual("Fail")
+  );
+});
+
+describe("#calculate", () => {
+  test("handles AAA", () =>
+    expect(Score.calculate("#ffffff", "#000000")) |> toEqual("AAA")
+  );
+
+  test("handles AA", () =>
+    expect(Score.calculate("#ffffff", "#666666")) |> toEqual("AA")
+  );
+
+  test("handles AA Large", () =>
+    expect(Score.calculate("#ffffff", "#888888")) |> toEqual("AA Large")
+  );
+
+  test("handles white on grayish", () =>
+    expect(Score.calculate("#ffffff", "#cccccc")) |> toEqual("Fail")
+  );
+});

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,1 +1,4 @@
-export declare const score: (foreground: string, background: string) => number
+export type Score = 'Fail' | 'AA Large' | 'AA' | 'AAA'
+export declare const ratio: (foreground: string, background: string) => number
+export declare const score: (foreground: string, background: string) => Score
+export declare const scoreFromRatio: (ratio: number) => Score

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,1 +1,1 @@
-export { score } from './es6/src/Color.bs'
+export { ratio, score, scoreFromRatio } from './es6/src/WCAG.bs'

--- a/src/Ratio.re
+++ b/src/Ratio.re
@@ -28,7 +28,7 @@ let parseColor = color =>
   |> Luminance.convert
   |> (v => v +. 0.05);
 
-let score = (foreground, background) => {
+let calculate = (foreground, background) => {
   switch (foreground |> Utils.removeHash, background |> Utils.removeHash) {
   | (fg, bg) when fg === bg => 1.0
   | (fg, bg) =>

--- a/src/Ratio.rei
+++ b/src/Ratio.rei
@@ -5,4 +5,4 @@ type t =
 let typeOfColor: Js.String.t => t;
 let parseNumbers: Js.String.t => Js.Array.t(float);
 let parseColor: Js.String.t => float;
-let score: (Js.String.t, Js.String.t) => float;
+let calculate: (Js.String.t, Js.String.t) => float;

--- a/src/Score.re
+++ b/src/Score.re
@@ -1,0 +1,10 @@
+let calculateFromRatio = ratio =>
+  switch (ratio) {
+  | r when r >= 7.0 => "AAA"
+  | r when r >= 4.5 => "AA"
+  | r when r >= 3.0 => "AA Large"
+  | _ => "Fail"
+  };
+
+let calculate = (foreground, background) =>
+  Ratio.calculate(foreground, background) |> calculateFromRatio;

--- a/src/Score.rei
+++ b/src/Score.rei
@@ -1,0 +1,2 @@
+let calculateFromRatio: float => string;
+let calculate: (Js.String.t, Js.String.t) => string;

--- a/src/Utils.rei
+++ b/src/Utils.rei
@@ -1,0 +1,1 @@
+let removeHash: Js.String.t => Js.String.t;

--- a/src/WCAG.re
+++ b/src/WCAG.re
@@ -1,0 +1,3 @@
+let ratio = Ratio.calculate;
+let score = Score.calculate;
+let scoreFromRatio = Score.calculateFromRatio;

--- a/src/WCAG.rei
+++ b/src/WCAG.rei
@@ -1,0 +1,3 @@
+let ratio: (Js.String.t, Js.String.t) => float;
+let score: (Js.String.t, Js.String.t) => string;
+let scoreFromRatio: float => string;


### PR DESCRIPTION
Fixes #2 

This adds a `score` and `scoreFromRatio` function that return a score value (Fail, AA Large, AA, AAA)

**BREAKING CHANGES:** Previous `score` function should actually have been named `ratio`, mistakes were made.